### PR TITLE
Functions which aren't a part of a class/trait can't have an access s…

### DIFF
--- a/tests/data/Sample.php
+++ b/tests/data/Sample.php
@@ -20,7 +20,7 @@ namespace What\A\SpecialNamespace
         protected function testMethod() {}
     }
 
-    public function test()
+    function test()
     {
         for ($i=0;$i<100;$i++) {
 


### PR DESCRIPTION
…pecifier

Removed public from function test which was not part of any class/trait in Sample.php(testing data)
